### PR TITLE
Apply PHP8 fixes to Tonic

### DIFF
--- a/issues/Issue105.php
+++ b/issues/Issue105.php
@@ -13,8 +13,8 @@ class Issue105 extends Resource {
    /**
      * @method GET
      * @secure 
-     * @param str $id
-     * @return str
+     * @param string $id
+     * @return string
      */
     public function getResource($id = 'Papa'){
         return 'Hello '.$id;
@@ -25,7 +25,7 @@ class Issue105 extends Resource {
      * @priority 2
      * @only self
      * @secure
-     * @return str
+     * @return string
      */
     public function getSelf() {
         return $this->getResource($this->username);

--- a/issues/Issue107.php
+++ b/issues/Issue107.php
@@ -11,7 +11,7 @@ class Issue107 extends Resource {
 
     /**
      * @method GET
-     * @param str $id
+     * @param string $id
      * @return Tonic\Response
      */
     public function get($id = 'default') {
@@ -29,7 +29,7 @@ class Issue107 extends Resource {
 
     /**
      * @method POST
-     * @return string
+     * @return stringing
      */
     public function create() {
         return "create";

--- a/spec/Tonic/ApplicationSpec.php
+++ b/spec/Tonic/ApplicationSpec.php
@@ -77,7 +77,6 @@ class ApplicationSpec extends ObjectBehavior
     {
         $request->getUri()->willReturn('/quux/baz');
         $params = array(
-            0 => 'baz',
             'quuux' => 'baz'
         );
         $request->getParams()->willReturn($params);

--- a/src/Tonic/Application.php
+++ b/src/Tonic/Application.php
@@ -195,9 +195,11 @@ class Application
                     array_shift($params);
                     $uriParams = $resourceMetadata->getUriParams($index);
                     if ($uriParams) { // has params within URI
+                        $namedParams = []; // restart with an empty params array
                         foreach ($uriParams as $key => $name) {
-                            $params[$name] = $params[$key];
+                            $namedParams[$name] = $params[$key];
                         }
+                        $params = $namedParams;
                     }
                     $matchedResource = array($resourceMetadata, $params);
                 }

--- a/src/Tonic/Application.php
+++ b/src/Tonic/Application.php
@@ -101,8 +101,8 @@ class Application
     /**
      * Add a namespace to a specific URI-space
      *
-     * @param str $namespaceName
-     * @param str $uriSpace
+     * @param string $namespaceName
+     * @param string $uriSpace
      */
     public function mount($namespaceName, $uriSpace)
     {
@@ -116,9 +116,9 @@ class Application
     /**
      * Get the URL for the given resource class
      *
-     * @param  str   $className
-     * @param  str[] $params
-     * @return str
+     * @param string   $className
+     * @param string[] $params
+     * @return string
      */
     public function uri($className, $params = array())
     {

--- a/src/Tonic/MetadataCache.php
+++ b/src/Tonic/MetadataCache.php
@@ -15,13 +15,13 @@ interface MetadataCache
 
     /**
      * Load the resource metadata from disk
-     * @return str[]
+     * @return string[]
      */
     public function load();
 
     /**
      * Save resource metadata to disk
-     * @param  str[]   $resources Resource metadata
+     * @param string[] $resources Resource metadata
      * @return boolean
      */
     public function save($resources);

--- a/src/Tonic/MetadataCacheAPC.php
+++ b/src/Tonic/MetadataCacheAPC.php
@@ -28,7 +28,7 @@ class MetadataCacheAPC implements MetadataCache
 
     /**
      * Load the resource metadata from disk
-     * @return str[]
+     * @return string[]
      */
     public function load()
     {
@@ -37,7 +37,7 @@ class MetadataCacheAPC implements MetadataCache
 
     /**
      * Save resource metadata to disk
-     * @param  str[]   $resources Resource metadata
+     * @param string[] $resources Resource metadata
      * @return boolean
      */
     public function save($resources)

--- a/src/Tonic/MetadataCacheFile.php
+++ b/src/Tonic/MetadataCacheFile.php
@@ -27,7 +27,7 @@ class MetadataCacheFile implements MetadataCache
 
     /**
      * Load the resource metadata from disk
-     * @return str[]
+     * @return string[]
      */
     public function load()
     {
@@ -36,7 +36,7 @@ class MetadataCacheFile implements MetadataCache
 
     /**
      * Save resource metadata to disk
-     * @param  str[]   $resources Resource metadata
+     * @param string[]   $resources Resource metadata
      * @return boolean
      */
     public function save($resources)

--- a/src/Tonic/Request.php
+++ b/src/Tonic/Request.php
@@ -73,11 +73,11 @@ class Request
      * Get an item from the given options array if it exists, otherwise fetch from HTTP header
      * or return the given default
      *
-     * @param  str[] $options
-     * @param  str $configVar Name of item to get
-     * @param  str|str[] $headers Name of HTTP header(s)
-     * @param  str $default Fallback value
-     * @return str
+     * @param string[] $options
+     * @param string $configVar Name of item to get
+     * @param string|str[] $headers Name of HTTP header(s)
+     * @param string $default Fallback value
+     * @return string
      */
     public function getOption($options, $configVar, $headers = null, $default = null)
     {
@@ -106,8 +106,8 @@ class Request
      *
      * Also gets private member via getter without explicitly using the getter.
      *
-     * @param str name
-     * @return str
+     * @param string name
+     * @return string
      */
     public function __get($name)
     {
@@ -120,7 +120,7 @@ class Request
     /**
      * Magic PHP method to set a private member without explicitly using the setter.
      *
-     * @param str name
+     * @param string name
      * @param mixed value
      */
     public function __set($name, $value)
@@ -284,8 +284,8 @@ class Request
 
     /**
      * Fetch the request URI from the server environment
-     * @param  str $options
-     * @return str
+     * @param string $options
+     * @return string
      */
     private function getURIFromEnvironment($options)
     {
@@ -327,8 +327,8 @@ class Request
 
     /**
      * Get accepted content mimetypes from request header
-     * @param  str   $acceptString
-     * @return str[]
+     * @param  string   $acceptString
+     * @return string[]
      */
     private function getAcceptArrayFromEnvironment($acceptString)
     {
@@ -356,8 +356,8 @@ class Request
 
     /**
      * Get if-match data from request header
-     * @param  str   $matchString
-     * @return str[]
+     * @param string   $matchString
+     * @return string[]
      */
     private function getMatchArrayFromEnvironment($matchString)
     {

--- a/src/Tonic/Resource.php
+++ b/src/Tonic/Resource.php
@@ -21,8 +21,8 @@ class Resource
 
     /**
      * Get a URL parameter as defined by this resource and it's URI
-     * @param  str $name Name of the parameter
-     * @return str
+     * @param string $name Name of the parameter
+     * @return string
      */
     public function __get($name)
     {
@@ -31,8 +31,8 @@ class Resource
 
     /**
      * Check if a URL parameter exists
-     * @param  str $name Name of the parameter
-     * @return str
+     * @param string $name Name of the parameter
+     * @return string
      */
     public function __isset($name)
     {
@@ -42,8 +42,8 @@ class Resource
     /**
      * Get the method name of the best matching resource method.
      *
-     * @param  str[] $resourceMetadata
-     * @return str
+     * @param string[] $resourceMetadata
+     * @return string
      */
     private function calculateMethodPriorities($resourceMetadata)
     {
@@ -206,7 +206,7 @@ class Resource
 
     /**
      * HTTP method condition must match request method
-     * @param str $method
+     * @param string $method
      */
     protected function method($method)
     {
@@ -227,7 +227,7 @@ class Resource
 
     /**
      * Accepts condition mimetype must match request content type
-     * @param str $mimetype
+     * @param string $mimetype
      */
     protected function accepts($mimetype)
     {
@@ -241,7 +241,7 @@ class Resource
     /**
      * Provides condition mimetype must be in request accept array, returns a number
      * based on the priority of the match.
-     * @param  str $mimetype
+     * @param string $mimetype
      * @return int
      */
     protected function provides($mimetype)
@@ -266,7 +266,7 @@ class Resource
     /**
      * Lang condition language code must be in request accept lang array, returns a number
      * based on the priority of the match.
-     * @param  str $language
+     * @param string $language
      * @return int
      */
     protected function lang($language)

--- a/src/Tonic/ResourceMetadata.php
+++ b/src/Tonic/ResourceMetadata.php
@@ -61,7 +61,7 @@ class ResourceMetadata implements \ArrayAccess
         $this->methods = $this->readMethodAnnotations($className);
     }
 
-    public function offsetExists($name)
+    public function offsetExists($name) : bool
     {
         return isset($this->$name);
     }
@@ -71,14 +71,14 @@ class ResourceMetadata implements \ArrayAccess
         return isset($this->$name) ? $this->$name : null;
     }
 
-    public function offsetSet($name, $value)
+    public function offsetSet($name, $value) : void
     {
         if (!is_null($name)) {
             $this->$name = $value;
         }
     }
 
-    public function offsetUnset($name)
+    public function offsetUnset($name) : void
     {
         $this->$name = null;
     }
@@ -148,7 +148,7 @@ class ResourceMetadata implements \ArrayAccess
 
     /**
      * Append the given URI-space to the resources URLs
-     * @param str $uriSpace
+     * @param string $uriSpace
      */
     public function mount($uriSpace)
     {
@@ -159,7 +159,7 @@ class ResourceMetadata implements \ArrayAccess
 
     /**
      * Get the class doccomment from the reflector or from the source file.
-     * @return str
+     * @return string
      */
     private function getDocComment($classReflector)
     {
@@ -180,8 +180,8 @@ class ResourceMetadata implements \ArrayAccess
 
     /**
      * Parse annotations out of a doc comment
-     * @param  str   $comment Doc comment to parse
-     * @return str[]
+     * @param  string   $comment Doc comment to parse
+     * @return string[]
      */
     private function parseDocComment($comment)
     {
@@ -200,8 +200,8 @@ class ResourceMetadata implements \ArrayAccess
 
     /**
      * Turn a URL template into a regular expression
-     * @param  str[] $uri URL template
-     * @return str[] Regular expression and parameter names
+     * @param string[] $uri URL template
+     * @return string[] Regular expression and parameter names
      */
     private function uriTemplateToRegex($uri)
     {

--- a/src/Tonic/Response.php
+++ b/src/Tonic/Response.php
@@ -101,8 +101,8 @@ class Response
 
     /**
      * Get a HTTP response header
-     * @param  str $name Header name, hyphens should be converted to camelcase
-     * @return str
+     * @param string $name Header name, hyphens should be converted to camelcase
+     * @return string
      */
     public function getHeader($name)
     {
@@ -111,8 +111,8 @@ class Response
 
     /**
      * Set a HTTP response header
-     * @param str $name  Header name, hyphens should be converted to camelcase
-     * @param str $value Header content
+     * @param string $name  Header name, hyphens should be converted to camelcase
+     * @param string $value Header content
      */
     public function setHeader($name, $value)
     {
@@ -122,8 +122,8 @@ class Response
     /**
      * Magic PHP method to get a HTTP response header.
      *
-     * @param str name
-     * @return str
+     * @param string name
+     * @return string
      */
     public function __get($name)
     {
@@ -133,8 +133,8 @@ class Response
     /**
      * Magic PHP method to set a HTTP response header.
      *
-     * @param str name
-     * @param str value
+     * @param string name
+     * @param string value
      */
     public function __set($name, $value)
     {

--- a/src/Tyrell/Hello.php
+++ b/src/Tyrell/Hello.php
@@ -27,8 +27,8 @@ class Hello extends Resource
      * response body, or a full Tonic\Response object.
      *
      * @method GET
-     * @param  str $name
-     * @return str
+     * @param string $name
+     * @return string
      */
     public function sayHello($name = 'World')
     {
@@ -40,8 +40,8 @@ class Hello extends Resource
      *
      * @method GET
      * @lang fr
-     * @param  str $name
-     * @return str
+     * @param string $name
+     * @return string
      */
     public function sayHelloInFrench($name = 'Monde')
     {
@@ -57,7 +57,7 @@ class Hello extends Resource
      * @method GET
      * @priority 2
      * @only deckard
-     * @return str
+     * @return string
      */
     public function replicants()
     {
@@ -73,7 +73,7 @@ class Hello extends Resource
      * @method GET
      * @priority 2
      * @only roy
-     * @return str
+     * @return string
      */
     public function iveSeenThings()
     {

--- a/src/Tyrell/Secret.php
+++ b/src/Tyrell/Secret.php
@@ -20,7 +20,7 @@ class Secret extends Tonic\Resource {
      *
      * @method GET
      * @secure aUser aPassword
-     * @return str
+     * @return string
      */
     function mySecret() {
         return 'My secret';
@@ -30,8 +30,8 @@ class Secret extends Tonic\Resource {
      * Condition method for the @secure annotation that checks the requests HTTP
      * authentication details against the username and password given in the annotation.
      *
-     * @param str $username
-     * @param str $password
+     * @param string $username
+     * @param string $password
      * @throws UnauthorizedException
      */
     function secure($username, $password) {


### PR DESCRIPTION
Tonic is old and crappy. Tonic uses `call_user_func_array()` to call the appropriate controller method and passes an overloaded array with URL parameters both numerically and string indexed. String indexed arguments in `call_user_func_array()` are now passed to the callback's correspondingly named parameters. Since you can't pass multiple arguments to the same parameter, this causes a FATAL ERROR.

@neefkenwick was nice enough to provide a fix. This PR merges in his fix and a few other small improvements he made.